### PR TITLE
Make Initializer for NoOpSensorCapturer Public

### DIFF
--- a/Sources/DataCapturing/Capturing/Sensors/NoOpSensorCapturer.swift
+++ b/Sources/DataCapturing/Capturing/Sensors/NoOpSensorCapturer.swift
@@ -29,6 +29,10 @@ import OSLog
 public class NoOpSensorCapturer: SensorCapturer {
     private var messagePublisher: PassthroughSubject<Message, Never>?
 
+    public init() {
+        // Nothing to do here, but we need a public initializer.
+    }
+
     public func start() -> AnyPublisher<Message, Never> {
         let messagePublisher = PassthroughSubject<Message, Never>()
         self.messagePublisher = messagePublisher
@@ -43,6 +47,4 @@ public class NoOpSensorCapturer: SensorCapturer {
         }
         os_log(.info, log: .sensor, "Stopping NoOpSensorCapturer!")
     }
-    
-    
 }


### PR DESCRIPTION
This is necessary so implementing Apps can actually use this class.