### PR TITLE
Add Range Header Parsing and Request Continuation

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -26,3 +26,11 @@ jobs:
       #run: xcodebuild -destination "platform=iOS Simulator,name=iPhone SE (3rd generation),OS=18.1" -scheme DataCapturing test
     - name: Build & Test
       run: xcodebuild clean test -scheme "DataCapturing" -destination "platform=iOS Simulator,name=iPhone SE (3rd generation),OS=latest" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO
+
+    - name: Archive Test Log
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: test-log
+        path: /Users/runner/Library/Developer/Xcode/DerivedData/**/Logs/Test/*.xcresult
+

--- a/Sources/DataCapturing/Synchronization/Upload/Background/BackgroundEventHandler.swift
+++ b/Sources/DataCapturing/Synchronization/Upload/Background/BackgroundEventHandler.swift
@@ -75,7 +75,6 @@ public class BackgroundEventHandler {
             messageBus.send(UploadStatus(upload: upload, status: .finishedSuccessfully))
 
         case 308: // Upload fortsetzen
-            // TODO: Header zum Fortsetzen setzen
             os_log("308", log: OSLog.synchronization, type: .debug)
             try sessionRegistry.record(
                 upload: upload,

--- a/Sources/DataCapturing/Synchronization/Upload/Background/BackgroundPreRequest.swift
+++ b/Sources/DataCapturing/Synchronization/Upload/Background/BackgroundPreRequest.swift
@@ -27,7 +27,7 @@ import Foundation
 
  - Author: Klemens Muthmann
  */
-struct BackgroundPreRequest {
+struct BackgroundPreRequest: CyfaceServerRequest {
     /// The location of a Cyface data collector service to send the request to.
     let collectorUrl: URL
     /// An iOS `URLSession` used to communicate with the server.
@@ -43,7 +43,7 @@ struct BackgroundPreRequest {
     ///
     /// The operation system decides when to actually send it.
     /// Depending on the provided session this will be instantaeous or happens if connected to a WiFi and a plug.
-    func send() throws {
+    func send() throws -> URLSessionTask {
         let metaData = try upload.metaData()
         let data = try upload.data()
         let httpMethod = "POST"
@@ -80,5 +80,7 @@ struct BackgroundPreRequest {
 
         preRequestTask.taskDescription = "PREREQUEST:\(upload.measurement.identifier)"
         preRequestTask.resume()
+        
+        return preRequestTask
     }
 }

--- a/Sources/DataCapturing/Synchronization/Upload/Background/BackgroundStatusRequest.swift
+++ b/Sources/DataCapturing/Synchronization/Upload/Background/BackgroundStatusRequest.swift
@@ -27,7 +27,7 @@ import Foundation
 
  - Author: Klemens Muthmann
  */
-struct BackgroundStatusRequest {
+struct BackgroundStatusRequest: CyfaceServerRequest {
     // MARK: - Properties
     /// The iOS `URLSession` used to upload data to the Data collector server.
     let session: URLSession
@@ -42,7 +42,7 @@ struct BackgroundStatusRequest {
 
      - Throws: `ServerConnectionError.invalidUploadLocation` if the provided `sessionIdentifier` is invalid.
      */
-    func send() throws {
+    func send() throws -> URLSessionTask {
         guard let requestLocation = upload.location else {
             throw ServerConnectionError.invalidUploadLocation("Missing Location")
         }
@@ -76,5 +76,7 @@ struct BackgroundStatusRequest {
         statusRequestTesk.countOfBytesClientExpectsToReceive = 50 + minimumBytesInAnHTTPResponse
         statusRequestTesk.taskDescription = "STATUS:\(upload.measurement.identifier)"
         statusRequestTesk.resume()
+
+        return statusRequestTesk
     }
 }

--- a/Sources/DataCapturing/Synchronization/Upload/Background/BackgroundUploadProcess.swift
+++ b/Sources/DataCapturing/Synchronization/Upload/Background/BackgroundUploadProcess.swift
@@ -61,7 +61,7 @@ public class BackgroundUploadProcess: NSObject {
         collectorUrl: URL,
         uploadFactory: UploadFactory,
         authenticator: Authenticator,
-        urlSession: URLSession,
+        urlSession: URLSession
     ) {
         self.sessionRegistry = sessionRegistry
         self.collectorUrl = collectorUrl

--- a/Sources/DataCapturing/Synchronization/Upload/Background/BackgroundUploadProcess.swift
+++ b/Sources/DataCapturing/Synchronization/Upload/Background/BackgroundUploadProcess.swift
@@ -16,8 +16,7 @@
  * You should have received a copy of the GNU General Public License
  * along with the Cyface SDK for iOS. If not, see <http://www.gnu.org/licenses/>.
  */
-
-import OSLog
+import Foundation
 import Combine
 
 /**
@@ -41,10 +40,11 @@ public class BackgroundUploadProcess: NSObject {
     public let uploadStatus = PassthroughSubject<UploadStatus, Never>()
     /// Store processing of upload status functions as long as this object is alive.
     var uploadStatusCancellable: AnyCancellable?
-    /// Handler for events occuring when a request has finished.
-    let eventHandler: BackgroundEventHandler
-    /// An implementation of all the delegates required by a background `URLSession`.
-    let eventDelegate: BackgroundProcessDelegate
+    /// Store the most recent request. This is necessary for iOS to not remove the reference aborting the request in the process.
+    ///
+    /// For a full implementation each and every task should be stored in its own variable. But since we do the requests only sequential,
+    /// storing only the most recent should be sufficient.
+    var activeRequestTask: URLSessionTask?
 
     // MARK: - Initializers
     /// Create a new complete instance of this class with the provided parameters.
@@ -56,23 +56,18 @@ public class BackgroundUploadProcess: NSObject {
     ///     - authenticator: Used to authenticate each request.
     ///     - urlSession: A `URLSession` to use for sending requests and receiving responses, probably in the background.
     ///     - eventHandler: Handler for events occuring when a request has finished.
-    ///     - eventDelegate: An implementation of all the delegates required by a background `URLSession`.
     init(
         sessionRegistry: SessionRegistry,
         collectorUrl: URL,
         uploadFactory: UploadFactory,
         authenticator: Authenticator,
         urlSession: URLSession,
-        eventHandler: BackgroundEventHandler,
-        eventDelegate: BackgroundProcessDelegate
     ) {
         self.sessionRegistry = sessionRegistry
         self.collectorUrl = collectorUrl
         self.uploadFactory = uploadFactory
         self.authenticator = authenticator
         self.discretionaryUrlSession = urlSession
-        self.eventHandler = eventHandler
-        self.eventDelegate = eventDelegate
         super.init()
 
         uploadStatusCancellable = uploadStatus.sink { status in
@@ -100,7 +95,7 @@ extension BackgroundUploadProcess: UploadProcess {
                 authToken: try await authenticator.authenticate(),
                 upload: upload
             )
-            try statusRequest.send()
+            self.activeRequestTask = try statusRequest.send()
             /// If the status request was successful continue by sending an upload starting at the byte given by the status request
             /// If the status request was not successful contnue with a pre request
             return upload
@@ -115,7 +110,7 @@ extension BackgroundUploadProcess: UploadProcess {
                 upload: upload,
                 authToken: try await authenticator.authenticate()
             )
-            try preRequest.send()
+            self.activeRequestTask = try preRequest.send()
             /// If the pre request was successful create a session and start uploading the data
             /// If the upload request completes see if another chunk is due to be uploaded
             /// If yes than start the upload for the next chunk

--- a/Sources/DataCapturing/Synchronization/Upload/Background/BackgroundUploadProcessBuilder.swift
+++ b/Sources/DataCapturing/Synchronization/Upload/Background/BackgroundUploadProcessBuilder.swift
@@ -123,7 +123,7 @@ public class BackgroundUploadProcessBuilder {
                 collectorUrl: collectorUrl,
                 uploadFactory: uploadFactory,
                 authenticator: authenticator,
-                urlSession: urlSession,
+                urlSession: urlSession
             )
         }
     }

--- a/Sources/DataCapturing/Synchronization/Upload/Background/BackgroundUploadProcessBuilder.swift
+++ b/Sources/DataCapturing/Synchronization/Upload/Background/BackgroundUploadProcessBuilder.swift
@@ -39,28 +39,6 @@ public protocol BackgroundURLSessionEventDelegate {
 /**
  One step from the ``BackgroundUploadProcessBuilder``.
 
- Add a ``BackgroundProcessDelegate`` to the ``BackgroundUploadProcess``.
-
- - Author: Klemens Muthmann
- */
-public protocol DelegateBuilder {
-    func add(delegate: BackgroundProcessDelegate) -> BuildFunction
-}
-
-/**
- One step from the ``BackgroundUploadProcessBuilder``.
-
- Add a ``BackgroundEventHandler`` to the ``BackgroundUploadProcess``.
-
- - Author: Klemens Muthmann
- */
-public protocol EventHandlerBuilder {
-    func add(handler: BackgroundEventHandler) -> DelegateBuilder
-}
-
-/**
- One step from the ``BackgroundUploadProcessBuilder``.
-
  Finally create the ``UploadProcess`` from this builder.
 
  - Author: Klemens Muthmann
@@ -92,7 +70,7 @@ public class BackgroundUploadProcessBuilder {
         uploadFactory: any UploadFactory,
         authenticator: any Authenticator,
         urlSession: URLSession
-    ) -> EventHandlerBuilder {
+    ) -> BuildFunction {
         return InternalBackgroundProcessBuilder(
             sessionRegistry: sessionRegistry,
             collectorUrl: collectorUrl,
@@ -110,9 +88,7 @@ public class BackgroundUploadProcessBuilder {
      - Author: Klemens Muthmann
      */
     public class InternalBackgroundProcessBuilder:
-        BuildFunction,
-            DelegateBuilder,
-            EventHandlerBuilder {
+        BuildFunction {
 
         // MARK: - Attributes
         /// A `URLSession` to use for sending requests and receiving responses, probably in the background.
@@ -125,10 +101,6 @@ public class BackgroundUploadProcessBuilder {
         let uploadFactory: UploadFactory
         /// Used by the created ``UploadProcess`` to authenticate and authorize uploads with the Cyface data collector.
         let authenticator: Authenticator
-        /// An implementation of all the delegates required by a background `URLSession`.
-        var delegate: BackgroundProcessDelegate?
-        /// Handler for events occuring when a request has finished.
-        var eventHandler: BackgroundEventHandler?
 
         // MARK: - Initializers
         init(
@@ -145,16 +117,6 @@ public class BackgroundUploadProcessBuilder {
             self.urlSession = urlSession
         }
 
-        public func add(handler: BackgroundEventHandler) -> any DelegateBuilder {
-            self.eventHandler = handler
-            return self
-        }
-
-        public func add(delegate: BackgroundProcessDelegate) -> any BuildFunction {
-            self.delegate = delegate
-            return self
-        }
-
         public func build() -> UploadProcess {
             return BackgroundUploadProcess(
                 sessionRegistry: sessionRegistry,
@@ -162,8 +124,6 @@ public class BackgroundUploadProcessBuilder {
                 uploadFactory: uploadFactory,
                 authenticator: authenticator,
                 urlSession: urlSession,
-                eventHandler: eventHandler!,
-                eventDelegate: delegate!
             )
         }
     }

--- a/Sources/DataCapturing/Synchronization/Upload/Background/BackgroundUploadRequest.swift
+++ b/Sources/DataCapturing/Synchronization/Upload/Background/BackgroundUploadRequest.swift
@@ -27,22 +27,17 @@ import OSLog
 
  - Author: Klemens Muthmann
  */
-struct BackgroundUploadRequest {
+struct BackgroundUploadRequest: CyfaceServerRequest {
     // MARK: - Properties
     /// The URL to the Cyface API receiving the data.
     let session: URLSession
     /// The logger used by objects of this class.
     let log: OSLog = OSLog(subsystem: "UploadRequest", category: "de.cyface")
     /// The ``Upload`` to send to the Cyface Collector Server.
-    let upload: any Upload
-    /// Start the upload from this byte in the upload data.
-    ///
-    /// The default is 0. If a ``BackgroundStatusRequest`` provides a different value, the upload may start from there.
-    /// This is usually the case if some data was uploaded previously and this is a continuation upload.
-    let continueOnByte: Int = 0
+    var upload: any Upload
 
     /// Send the request for the provided `upload`.
-    func send() throws {
+    func send() throws -> URLSessionTask {
         os_log("Upload Request: Uploading measurement %{public}d to %{public}@.", log: log, type: .debug, upload.measurement.identifier, upload.location?.absoluteString ?? "Location Missing!")
         let metaData = try upload.metaData()
         let data = try upload.data()
@@ -52,19 +47,24 @@ struct BackgroundUploadRequest {
         }
 
         // Background uploads are only valid from files, so writing the data to a file at first.
-        let dataToUpload = data[continueOnByte..<data.count]
+        let continueOnByte = upload.bytesUploaded
+        let uploadToByte = data.count
+
+        let dataToUpload = data[continueOnByte..<uploadToByte]
         let tempDataFile = try copyToTemp(data: dataToUpload, filename: url.lastPathComponent)
 
         var request = URLRequest(url: url)
         request.httpMethod = "PUT"
         metaData.add(to: &request)
-        request.setValue(String(data.count-continueOnByte), forHTTPHeaderField: "Content-Length")
-        request.setValue("bytes \(continueOnByte)-\(data.count-1)/\(data.count)", forHTTPHeaderField: "Content-Range")
+        request.setValue(String(uploadToByte-continueOnByte), forHTTPHeaderField: "Content-Length")
+        request.setValue("bytes \(continueOnByte)-\(uploadToByte-1)/\(uploadToByte-continueOnByte)", forHTTPHeaderField: "Content-Range")
 
         let uploadTask = session.uploadTask(with: request, fromFile: tempDataFile)
         uploadTask.countOfBytesClientExpectsToSend = Int64(dataToUpload.count) + headerBytes(request)
         uploadTask.countOfBytesClientExpectsToReceive = minimumBytesInAnHTTPResponse
         uploadTask.taskDescription = "UPLOAD:\(upload.measurement.identifier)"
         uploadTask.resume()
+
+        return uploadTask
     }
 }

--- a/Sources/DataCapturing/Synchronization/Upload/Background/CyfaceServerRequest.swift
+++ b/Sources/DataCapturing/Synchronization/Upload/Background/CyfaceServerRequest.swift
@@ -16,19 +16,14 @@
  * You should have received a copy of the GNU General Public License
  * along with the Cyface SDK for iOS. If not, see <http://www.gnu.org/licenses/>.
  */
+import Foundation
 
 /**
- Errors occuring during the ``UploadProcess``.
-
- - Author: Klemens Muthmann
+ Base protocol for all requests issued during data upload, via the Cyface Upload Protocol.
  */
-public enum UploadProcessError: Error {
-    /// Initialization was wrong. You need to provide a valid `URLSession` before calling any methods on an `UploadProcess`.
-    case missingUrlSession
-    /// Received a response and tried to find out which bytes had been uploaded but the range header was missing.
-    case missingRangeHeader
-    /// Tried to parse a range header in an HTTP response but it contained an unparseable value.
-    case invalidRangeHeaderValue
-    /// Parsed a range header but could not convert the uploadedBytes value to a 64 Bit Integer.
-    case uploadedBytesUnparseable
+protocol CyfaceServerRequest {
+    /// Provide the `UploadTask` used for the request.
+    ///
+    /// You need to store this reference as long as the upload runs, or it will be discarded.
+    func send() throws -> URLSessionTask
 }

--- a/Sources/DataCapturing/Synchronization/Upload/Default/UploadRequest.swift
+++ b/Sources/DataCapturing/Synchronization/Upload/Default/UploadRequest.swift
@@ -37,7 +37,7 @@ class UploadRequest {
     }
 
     /// Send the request for the provided `upload`.
-    func request(authToken: String, upload: any Upload, continueOnByte: Int = 0) async throws -> any Upload {
+    func request(authToken: String, upload: any Upload) async throws -> any Upload {
         os_log("Uploading measurement %{public}d to %{public}@.", log: log, type: .debug, upload.measurement.identifier, upload.location?.absoluteString ?? "Location Missing!")
         let metaData = try upload.metaData()
         let data = try upload.data()
@@ -47,6 +47,7 @@ class UploadRequest {
         }
 
         // Background uploads are only valid from files, so writing the data to a file at first.
+        let continueOnByte = upload.bytesUploaded
         let tempDataFile = try copyToTemp(data: data[continueOnByte..<data.count], filename: url.lastPathComponent)
 
         var request = URLRequest(url: url)

--- a/Sources/DataCapturing/Synchronization/Upload/Upload.swift
+++ b/Sources/DataCapturing/Synchronization/Upload/Upload.swift
@@ -27,11 +27,13 @@ import Foundation
 public protocol Upload: Equatable {
     // MARK: - Properties
     /// A list of failures caused by this upload, if any.
-    var failures: [Error] {get}
+    var failures: [Error] { get }
     /// The ``FinishedMeasurement`` to upload.
     var measurement: FinishedMeasurement { get }
     /// The location to send the data to or `nil` if no location was requested from the server yet.
-    var location: URL? {get set}
+    var location: URL? { get set }
+    /// Return the number of bytes already uploaded. This is used to resume a previously interrupted upload.
+    var bytesUploaded: Int { get set }
 
     // MARK: - Methods
     /// Provide the upload meta data of the measurement to upload.
@@ -57,6 +59,7 @@ public class CoreDataBackedUpload: Upload {
     public var failures: [Error]
     /// The location of the active session for this upload or `nil` if no successful pre request has been send and received yet.
     public var location: URL?
+    public var bytesUploaded: Int = 0
     // MARK: - Internal Properties
     /// A wrapper for the `NSPersistentContainer` and the corresponding initialization code.
     var dataStoreStack: DataStoreStack

--- a/Tests/DataCapturingTests/Support/Mocks/MockUpload.swift
+++ b/Tests/DataCapturingTests/Support/Mocks/MockUpload.swift
@@ -43,6 +43,7 @@ class MockUpload: Upload {
     /// An optionally empty location to store the upload at.
     var location: URL?
     var failures: [any Error]
+    var bytesUploaded: Int = 0
 
     // MARK: - Initializers
     /// Initialize this class with a simulated measurement identifier.
@@ -56,15 +57,15 @@ class MockUpload: Upload {
     /// Provide non sense test meta data about this upload.
     func metaData() throws -> MetaData {
         let ret = MetaData(
-            locationCount: 3,
-            formatVersion: 2,
-            startLocLat: 1.0,
-            startLocLon: 1.0,
-            startLocTS: Date(timeIntervalSince1970: 10_000),
-            endLocLat: 1.0,
-            endLocLon: 1.0,
-            endLocTS: Date(timeIntervalSince1970: 10_100),
-            measurementId: 1,
+            locationCount: UInt64(measurement.tracks.map{$0.locations.count}.reduce(into: 0) { $0 += $1 }),
+            formatVersion: 3,
+            startLocLat: measurement.tracks.first?.locations.first?.latitude,
+            startLocLon: measurement.tracks.first?.locations.first?.longitude,
+            startLocTS: measurement.tracks.first?.locations.first?.time,
+            endLocLat: measurement.tracks.last?.locations.last?.latitude,
+            endLocLon: measurement.tracks.last?.locations.last?.longitude,
+            endLocTS: measurement.tracks.last?.locations.last?.time,
+            measurementId: measurement.identifier,
             osVersion: "ios12",
             applicationVersion: "10.0.0",
             length: 10.0,

--- a/Tests/DataCapturingTests/Synchronization/DataUploadIT.swift
+++ b/Tests/DataCapturingTests/Synchronization/DataUploadIT.swift
@@ -1,0 +1,296 @@
+/*
+ * Copyright 2025 Cyface GmbH
+ *
+ * This file is part of the Ready for Robots App.
+ *
+ * The Ready for Robots App is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Ready for Robots App is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Ready for Robots App. If not, see <http://www.gnu.org/licenses/>.
+ */
+import OSLog
+import Foundation
+import Testing
+@testable import DataCapturing
+
+let log = OSLog(subsystem: "DataUploadIT", category: "de.cyface.test")
+
+@Test("Check if a basic upload works as expected.", .disabled("Since this test send actual data to the Cyface Staging Server it should only be executed manually in a controlled environment. Usually this means it should run locally on a developers machine prior to a new release but not from within continous integration. Before you run this test you need to set the four parameters at the top to appropriate values and NEVER commit them to version control!"))
+func upload() async throws {
+    let collectionUrl = URL(string: "")!
+    // Our Keycloak Instance contains a test client for such cases. Use that client here.
+    let authUrl = ""
+    let clientId = ""
+    let clientSecret = ""
+
+    let delegate = TestSessionDelegate()
+
+    let urlSession = try #require(delegate.session)
+    let testTrack = Track()
+    testTrack.locations = [
+        TestFixture.randomLocation(),
+        TestFixture.randomLocation(),
+        TestFixture.randomLocation(),
+        TestFixture.randomLocation(),
+        TestFixture.randomLocation()
+    ]
+    let measurement = FinishedMeasurement(
+        identifier: 14,
+        synchronizable: true,
+        synchronized: false,
+        time: Date(),
+        events: [Event](),
+        tracks: [testTrack],
+        accelerationData: Data(),
+        rotationData: Data(),
+        directionData: Data()
+    )
+    let upload = MockUpload(measurement: measurement)
+
+    // Authenticate
+    let authService = KeycloakAuthService(
+        authURL: authUrl,
+        clientID: clientId,
+        clientSecret: clientSecret) // TODO: Remove the Client Secret
+    let authToken = try await authService.requestAuthToken()
+
+    let preRequest = BackgroundPreRequest(
+        collectorUrl: collectionUrl,
+        session: urlSession,
+        upload: upload,
+        authToken: authToken
+    )
+    let (preRequestData, preRequestResponse) = try await delegate.send(preRequest)
+
+    #expect(preRequestResponse?.statusCode == 200)
+    os_log("Pre Request Location: %@", log: log, type: .debug, preRequestResponse?.allHeaderFields["Location"] as? String ?? "None")
+    let uploadLocation = try #require(preRequestResponse?.allHeaderFields["Location"] as? String)
+    upload.location = URL(string: uploadLocation)
+
+    let uploadRequest = BackgroundUploadRequest(
+        session: urlSession,
+        upload: upload
+    )
+
+    let (_, uploadRequestResponse) = try await delegate.send(uploadRequest)
+
+    #expect(uploadRequestResponse?.statusCode == 201)
+    os_log("Upload Response Header fields \n%@", log: log, type: .debug, uploadRequestResponse?.allHeaderFields ?? "None")
+
+    let statusRequest = BackgroundStatusRequest(
+        session: urlSession,
+        authToken: authToken,
+        upload: upload
+    )
+    let (_, statusRequestResponse) = try await delegate.send(statusRequest)
+
+    #expect(statusRequestResponse?.statusCode == 200)
+    os_log("Status Response Header fields \n%@", log: log, type: .debug, statusRequestResponse?.allHeaderFields ?? "None")
+
+    delegate.cleanUp()
+}
+
+/**
+ A `URLSessionDataDelegate` used to catch responses and return them to the test for assertion.
+ */
+class TestSessionDelegate: NSObject, URLSessionDataDelegate {
+    // MARK: - Internal Properties
+    /// This contains the data received a body from a URL request.
+    private var receivedData = Data()
+    /// A strong reference to the Continuation is required here.
+    /// We must ensure that the Continuation is always resumed/thrown,
+    /// to prevent the test from hanging.
+    private var continuation: CheckedContinuation<(Data, HTTPURLResponse?), Error>?
+
+    // MARK: - Properties
+    /// The delegate manages its own session.
+    var session: URLSession?
+    /// A strong reference to the current task is also required or else upload will be interrupted.
+    var currentTask: URLSessionTask?
+
+    // MARK: - Initializers/Deinitializers
+    override init() {
+        super.init()
+
+        // Create the session here to enable using `self` as a delegate.
+        let configuration = URLSessionConfiguration.default
+        configuration.waitsForConnectivity = true
+        self.session = URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
+    }
+
+    deinit {
+        os_log("Destroying TestSessionDelegate! (Should happen last)", log: log, type: .info)
+    }
+
+    // MARK: - Methods
+    /// Send the provided `CyfaceServerRequest` asynchronosly and return the body data as well as the response object.
+    func send(_ request: CyfaceServerRequest) async throws -> (Data, HTTPURLResponse?) {
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<(Data, HTTPURLResponse?), Error>) in
+            self.continuation = continuation
+            do {
+                currentTask = try request.send()
+            } catch {
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+
+    /// Finish the URLSession after being finished with the delegate.
+    ///
+    /// This is probably unnecessary, if the test is finished without using multiple delegates.
+    func cleanUp() {
+        self.session?.finishTasksAndInvalidate()
+    }
+}
+
+// MARK: - URLSessionDelegate implementation
+extension TestSessionDelegate: URLSessionDelegate {
+
+    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive response: URLResponse,
+                    completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
+        guard let response = response as? HTTPURLResponse,
+              (200...399).contains(response.statusCode) else {
+            // Bei Fehler die Continuation fortsetzen mit einem Fehler
+            continuation?.resume(throwing: URLError(.badServerResponse))
+            continuation = nil // Set to nil to avoid multiple continuations.
+            completionHandler(.cancel)
+            return
+        }
+        completionHandler(.allow)
+    }
+
+    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        self.receivedData.append(data)
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        if let error = error {
+            print("Task completed with error: \(error)")
+            continuation?.resume(throwing: error)
+        } else {
+            print("Task completed successfully. Received \(receivedData.count) bytes.")
+            // Resume without error.
+            continuation?.resume(returning: (receivedData, task.response as? HTTPURLResponse))
+        }
+        continuation = nil
+    }
+}
+
+/**
+ A service class to get an auth token from a Keycloak OAuth Server.
+ */
+class KeycloakAuthService {
+
+    // The URL for the token endpoint.
+    private let tokenURLString: String
+    // The id if the client to use for authentication.
+    private let clientID: String
+    // The secret used by the client for authentication.
+    private let clientSecret: String
+
+    init(authURL: String, clientID: String, clientSecret: String) {
+        self.tokenURLString = authURL
+        self.clientID = clientID
+        self.clientSecret = clientSecret
+    }
+
+    /// Request an authentication token from the Keycloak OAuth Server.
+    func requestAuthToken() async throws -> String {
+
+        guard let url = URL(string: tokenURLString) else {
+            throw AuthError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+
+        let parameters = [
+            "grant_type": "client_credentials",
+            "client_id": clientID,
+            "client_secret": clientSecret
+        ]
+
+        // Parameter URL encoding
+        let postString = parameters.map { (key, value) in
+            return "\(key)=\(value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")"
+        }.joined(separator: "&")
+
+        request.httpBody = postString.data(using: .utf8)
+
+        return try await withCheckedThrowingContinuation { continuation in
+            let task = URLSession.shared.dataTask(with: request) { data, response, error in
+                if let error = error {
+                    return continuation.resume(throwing: error)
+                }
+
+                guard let httpResponse = response as? HTTPURLResponse else {
+                    return continuation.resume(throwing: AuthError.invalidResponse)
+                }
+
+                guard (200...299).contains(httpResponse.statusCode) else {
+                    if let data = data, let errorString = String(data: data, encoding: .utf8) {
+                        print("Server responded with error: \(httpResponse.statusCode) - \(errorString)")
+                        continuation.resume(throwing: AuthError.serverError(statusCode: httpResponse.statusCode, message: errorString))
+                    } else {
+                        continuation.resume(throwing: AuthError.serverError(statusCode: httpResponse.statusCode, message: "Unknown server error"))
+                    }
+                    return
+                }
+
+                guard let data = data else {
+                    return continuation.resume(throwing: AuthError.noData)
+                }
+
+                do {
+                    if let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+                       let accessToken = json["access_token"] as? String {
+                        continuation.resume(returning: accessToken)
+                    } else {
+                        continuation.resume(throwing: AuthError.invalidJSONResponse)
+                    }
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+            task.resume()
+        }
+    }
+
+    /// Errors that might occur during authentication.
+    enum AuthError: LocalizedError {
+        /// Thrown if the autentication URL was invalid.
+        case invalidURL
+        /// Thrown if the auth server returned an invalid response
+        case invalidResponse
+        /// Thrown if the auth response was missing its body
+        case noData
+        /// Thrown if the auth response body was not parseable as proper JSON.
+        case invalidJSONResponse
+        /// Thrown if the auth server returned an erroneous response status code.
+        case serverError(statusCode: Int, message: String)
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidURL:
+                return "The authentication URL is invalid."
+            case .invalidResponse:
+                return "The server response was invalid."
+            case .noData:
+                return "No data received in the server response."
+            case .invalidJSONResponse:
+                return "The server's JSON response could not be parsed or did not contain an 'access_token'."
+            case .serverError(let statusCode, let message):
+                return "Server error \(statusCode): \(message)"
+            }
+        }
+    }
+}


### PR DESCRIPTION
With this commit we add the still missing ability to continue a previously interrupted upload from the point where it was interrupted instead of starting new.