### PR TITLE
Set the idToken on init

### DIFF
--- a/Sources/DataCapturing/Synchronization/Authentication/OAuthAuthenticationError.swift
+++ b/Sources/DataCapturing/Synchronization/Authentication/OAuthAuthenticationError.swift
@@ -35,6 +35,28 @@ public enum OAuthAuthenticatorError: Error {
     case invalidState
 }
 
+extension OAuthAuthenticatorError: Equatable {
+    public static func == (lhs: OAuthAuthenticatorError, rhs: OAuthAuthenticatorError) -> Bool {
+        switch (lhs, rhs) {
+        case (.tokenMissing, .tokenMissing),
+             (.invalidToken, .invalidToken),
+             (.invalidResponse, .invalidResponse),
+             (.missingCallbackController, .missingCallbackController),
+             (.missingResponse, .missingResponse),
+             (.invalidState, .invalidState):
+            return true
+        case (.errorResponse(let l), .errorResponse(let r)):
+            return l == r
+        case (.missingAuthState, .missingAuthState):
+            return true  // Error? does not conform to Equatable; causes are ignored
+        case (.discoveryFailed(let l), .discoveryFailed(let r)):
+            return l == r
+        default:
+            return false
+        }
+    }
+}
+
 extension OAuthAuthenticatorError: LocalizedError {
     /// Internationalized human readable description of the error.
     public var errorDescription: String? {

--- a/Sources/DataCapturing/Synchronization/Authentication/OAuthAuthenticator.swift
+++ b/Sources/DataCapturing/Synchronization/Authentication/OAuthAuthenticator.swift
@@ -96,6 +96,7 @@ public class OAuthAuthenticator {
             self.authStateKey = OAuthAuthenticator.appAuthStateKey
         }
         self._authState = try? loadState(self.authStateKey)
+        self.idToken = self._authState?.lastTokenResponse?.idToken
     }
 
     // MARK: - Methods
@@ -287,7 +288,6 @@ extension OAuthAuthenticator: Authenticator {
                                 continuation.resume(throwing: error)
                             }
                         } else if let accessToken = accessToken {
-                            self.idToken = idToken
                             try self.authState(from: authState)
                             continuation.resume(returning: accessToken)
                         } else {
@@ -372,8 +372,7 @@ extension OAuthAuthenticator: Authenticator {
     public func logout() async throws {
         os_log("Authentication: Logging Out", log: OSLog.authorization, type: .debug)
         guard let idToken = self.idToken else {
-            // TODO: Throw proper Exception here.
-            fatalError()
+            throw OAuthAuthenticatorError.tokenMissing
         }
 
         let request = await OIDEndSessionRequest(

--- a/Tests/DataCapturingTests/Synchronization/AuthenticatorTests.swift
+++ b/Tests/DataCapturingTests/Synchronization/AuthenticatorTests.swift
@@ -22,6 +22,26 @@ import Foundation
 import AppAuth
 @testable import DataCapturing
 
+@Test("Test that logout throws tokenMissing when no idToken is available.", .tags(.authentication, .synchronization))
+func logoutWithNilIdTokenThrowsTokenMissing() async {
+    // Arrange: fresh authenticator with no saved auth state → idToken is nil
+    let testStateKey = "de.cyface.test.authstate.logout"
+    let oocut = OAuthAuthenticator(
+        issuer: URL(string: "http://localhost/")!,
+        redirectUri: URL(string: "http://localhost/callback")!,
+        apiEndpoint: URL(string: "http://localhost/api")!,
+        clientId: "ios-client",
+        authStateKey: testStateKey
+    )
+    // Wipe any leftover state from a previous run so idToken stays nil
+    try? oocut.saveState(nil, testStateKey)
+
+    // Act & Assert
+    await #expect(throws: OAuthAuthenticatorError.tokenMissing) {
+        try await oocut.logout()
+    }
+}
+
 @Test("Test that saving the authentication state and reloading from disk works, as expected.", .tags(.authentication, .synchronization))
 func savingAuthStateHappyPath() async throws {
     // Arrange


### PR DESCRIPTION
Appareantly this is not done with property observer didSet when called from within an initializer.